### PR TITLE
Add basic synchronization capabilities

### DIFF
--- a/open_ephys/analysis/README.md
+++ b/open_ephys/analysis/README.md
@@ -90,3 +90,44 @@ If spike data has been saved by your Record Node (i.e., there is a Spike Detecto
 - `metadata` - `dict` with metadata about each electrode
 
 
+## Synchronizing timestamps
+
+If your recording contains data from multiple processors or subprocessors, you'll likely want to synchronize their timestamps prior to further analysis.
+
+Assuming they each have one event channel that was connected to the same *physical digital input line*, synchronization is straightforward.
+
+First, indicate which event channels share the sync input (this will depend on your recording configuration):
+
+```python
+recording = session.recordnodes[0].recording[0]
+
+recording.add_sync_channel(8,          # event channel number
+                           102,        # processor ID
+                           0,          # subprocessor ID (defaults to 0)
+                           main=True)  # use as the main timestamps
+
+recording.add_sync_channel(1,          # event channel number
+                           100,        # processor ID
+                           0,          # subprocessor ID (defaults to 0)
+                           main=False)  # align to the main timestamps
+
+recording.add_sync_channel(1,          # event channel number
+                           100,        # processor ID
+                           1,          # subprocessor ID (defaults to 0)
+                           main=False)  # align to the main timestamps
+```
+
+You must have one and only one "main" processor, and at least one "auxiliary" processor for synchronization to work.
+
+Next, running:
+
+```python
+recording.compute_global_timestamps()
+```
+
+will generate `global_timestamps` values for each `Continuous` object with a sync channel, as well as a `global_timestamp` column in the `recording.events` DataFrame.
+
+Now, you can work with your data aligned to a common timebase.
+
+
+

--- a/open_ephys/analysis/formats/BinaryRecording.py
+++ b/open_ephys/analysis/formats/BinaryRecording.py
@@ -96,7 +96,7 @@ class BinaryRecording(Recording):
         for events_directory in events_directories:
             
             node_name = os.path.basename(os.path.dirname(events_directory))
-            nodeId = int(node_name.split('-')[1].split('.')[0])
+            nodeId = int(node_name.split('-')[-1].split('.')[0])
             
             channels = np.load(os.path.join(events_directory, 'channels.npy'))
             timestamps = np.load(os.path.join(events_directory, 'timestamps.npy'))

--- a/open_ephys/analysis/formats/BinaryRecording.py
+++ b/open_ephys/analysis/formats/BinaryRecording.py
@@ -71,6 +71,7 @@ class BinaryRecording(Recording):
        Recording.__init__(self, directory, experiment_index, recording_index)  
        
        self.info = json.load(open(os.path.join(self.directory, 'structure.oebin')))
+       self._format = 'binary'
        
     def load_continuous(self):
         
@@ -126,7 +127,7 @@ class BinaryRecording(Recording):
             
         if len(df) > 0:
                                                
-            self._events = pd.concat(df).sort_values(by='timestamp')
+            self._events = pd.concat(df).sort_values(by='timestamp', ignore_index=True)
 
         else:
             

--- a/open_ephys/analysis/formats/BinaryRecording.py
+++ b/open_ephys/analysis/formats/BinaryRecording.py
@@ -118,8 +118,8 @@ class BinaryRecording(Recording):
         
             df.append(pd.DataFrame(data = {'channel' : channels,
                               'timestamp' : timestamps,
-                              'nodeId' : [nodeId] * len(channels),
-                              'subprocessorId' : [subProcessorId] * len(channels),
+                              'processor_id' : [nodeId] * len(channels),
+                              'subprocessor_id' : [subProcessorId] * len(channels),
                               'state' : (channel_states / channels + 1 / 2).astype('int')}))
             
         

--- a/open_ephys/analysis/formats/KwikRecording.py
+++ b/open_ephys/analysis/formats/KwikRecording.py
@@ -77,6 +77,11 @@ class KwikRecording(Recording):
 
             self.timestamps = np.arange(start_time, start_time + self.samples.shape[0])
             
+            self.metadata = {}
+            self.metadata['processor_id'] = int(os.path.basename(file).split('_')[1].split('.raw')[0])
+            self.metadata['subprocessor_id'] = 0 # format doesn't support subprocessors
+            self.metadata['sample_rate'] =  dataset['application_data']['channel_sample_rates'][0]
+            
             f.close()
     
     def __init__(self, directory, experiment_index=0, recording_index=0):
@@ -121,7 +126,8 @@ class KwikRecording(Recording):
         
         self._events = pd.DataFrame(data = {'channel' : dataset['event_channels'][()][mask] + 1,
                               'timestamp' : timestamps[mask],
-                              'nodeId' : dataset['nodeID'][()][mask],
+                              'processor_id' : dataset['nodeID'][()][mask],
+                              'subprocessor_id' : [0] * np.sum(mask),
                               'state' : dataset['eventID'][mask].astype('int')})
         
         f.close()

--- a/open_ephys/analysis/formats/KwikRecording.py
+++ b/open_ephys/analysis/formats/KwikRecording.py
@@ -85,7 +85,9 @@ class KwikRecording(Recording):
             f.close()
     
     def __init__(self, directory, experiment_index=0, recording_index=0):
+        
        Recording.__init__(self, directory, experiment_index, recording_index)  
+       self._format = 'kwik'
        
     def load_continuous(self):
         

--- a/open_ephys/analysis/formats/KwikRecording.py
+++ b/open_ephys/analysis/formats/KwikRecording.py
@@ -79,7 +79,7 @@ class KwikRecording(Recording):
             
             f.close()
     
-    def __init__(self, directory, experiment_index, recording_index):
+    def __init__(self, directory, experiment_index=0, recording_index=0):
        Recording.__init__(self, directory, experiment_index, recording_index)  
        
     def load_continuous(self):

--- a/open_ephys/analysis/formats/NwbRecording.py
+++ b/open_ephys/analysis/formats/NwbRecording.py
@@ -77,7 +77,9 @@ class NwbRecording(Recording):
             self.metadata['subprocessor_id'] = 0
     
     def __init__(self, directory, experiment_index=0, recording_index=0):
+        
        Recording.__init__(self, directory, experiment_index, recording_index)  
+       self._format = 'nwb'
        
     def open_file(self):
         

--- a/open_ephys/analysis/formats/NwbRecording.py
+++ b/open_ephys/analysis/formats/NwbRecording.py
@@ -72,7 +72,7 @@ class NwbRecording(Recording):
             self.timestamps = dataset['timestamps'][()]
             
             self.metadata = {}
-            self.metadata['sample_rate'] = np.mean(np.diff(self.timestamps))
+            self.metadata['sample_rate'] = 1/np.mean(np.diff(self.timestamps))
             self.metadata['processor_id'] = int(dataset.name.split('_')[1])
             self.metadata['subprocessor_id'] = 0
     

--- a/open_ephys/analysis/formats/NwbRecording.py
+++ b/open_ephys/analysis/formats/NwbRecording.py
@@ -71,7 +71,7 @@ class NwbRecording(Recording):
             self.samples = dataset['data'][()]
             self.timestamps = dataset['timestamps'][()]
     
-    def __init__(self, directory, experiment_index, recording_index):
+    def __init__(self, directory, experiment_index=0, recording_index=0):
        Recording.__init__(self, directory, experiment_index, recording_index)  
        
     def open_file(self):

--- a/open_ephys/analysis/formats/NwbRecording.py
+++ b/open_ephys/analysis/formats/NwbRecording.py
@@ -70,6 +70,11 @@ class NwbRecording(Recording):
             
             self.samples = dataset['data'][()]
             self.timestamps = dataset['timestamps'][()]
+            
+            self.metadata = {}
+            self.metadata['sample_rate'] = np.mean(np.diff(self.timestamps))
+            self.metadata['processor_id'] = int(dataset.name.split('_')[1])
+            self.metadata['subprocessor_id'] = 0
     
     def __init__(self, directory, experiment_index=0, recording_index=0):
        Recording.__init__(self, directory, experiment_index, recording_index)  
@@ -109,12 +114,13 @@ class NwbRecording(Recording):
         dataset = f['acquisition']['timeseries']['recording' + 
                                                  str(self.recording_index+1)]['events']['ttl1']
         
-        nodeId = int(dataset.attrs['source'].decode('utf-8').split('_')[1])
+        nodeId = int(dataset.attrs['source'].split('_')[1])
         timestamps = dataset['timestamps']
         
         self._events = pd.DataFrame(data = {'channel' : dataset['control'][()],
                               'timestamp' : timestamps,
-                              'nodeId' : [nodeId] * len(timestamps),
+                              'processor_id' : [nodeId] * len(timestamps),
+                              'subprocessor_id' : [0] * len(timestamps),
                               'state' : (np.sign(dataset['data'][()]) + 1 / 2).astype('int')})
         
         f.close()

--- a/open_ephys/analysis/formats/OpenEphysRecording.py
+++ b/open_ephys/analysis/formats/OpenEphysRecording.py
@@ -43,6 +43,7 @@ class OpenEphysRecording(Recording):
             files = [file for file in files if os.path.basename(file).split('_')[0] == processor_id]
             
             self.timestamps, _, _ = load(files[0], recording_index)
+            self.global_timestamps = None
             
             self.samples = np.zeros((len(self.timestamps), len(files)))
             self.metadata = {}
@@ -59,7 +60,7 @@ class OpenEphysRecording(Recording):
                 timestamps, samples, header = load(file, recording_index)
 
                 self.samples[:,channel_number] = samples
-            
+                
     class Spikes:
         
         def __init__(self, files, recording_index):
@@ -91,7 +92,7 @@ class OpenEphysRecording(Recording):
             self.waveforms = self.waveforms[order,:,:]
             self.electrodes = self.electrodes[order]
             
-    def __init__(self, directory, experiment_index, recording_index):
+    def __init__(self, directory, experiment_index=0, recording_index=0):
        Recording.__init__(self, directory, experiment_index, recording_index)  
        
        if experiment_index == 0:

--- a/open_ephys/analysis/formats/OpenEphysRecording.py
+++ b/open_ephys/analysis/formats/OpenEphysRecording.py
@@ -100,12 +100,15 @@ class OpenEphysRecording(Recording):
             self.electrodes = self.electrodes[order]
             
     def __init__(self, directory, experiment_index=0, recording_index=0):
+        
        Recording.__init__(self, directory, experiment_index, recording_index)  
        
        if experiment_index == 0:
            self.experiment_id = ""
        else:
            self.experiment_id = "_" + str(experiment_index+1)
+           
+       self._format = 'open-ephys'
        
     def load_continuous(self):
         

--- a/open_ephys/analysis/recording.py
+++ b/open_ephys/analysis/recording.py
@@ -24,6 +24,7 @@ SOFTWARE.
 
 
 from abc import ABC, abstractmethod
+import warnings
     
 class Recording(ABC):
     """ Abstract class representing data from a single Recording
@@ -74,7 +75,7 @@ class Recording(ABC):
             self.load_spikes()
         return self._spikes
     
-    def __init__(self, directory, experiment_index, recording_index):
+    def __init__(self, directory, experiment_index=0, recording_index=0):
         """ Construct a Recording object, which provides access to
         data from one recording (start/stop acquisition or start/stop recording)
 
@@ -84,8 +85,10 @@ class Recording(ABC):
             path to Record Node directory (e.g. 'Record Node 108')
         experiment_index : int
             0-based index of experiment
+            defaults to 0
         recording_index : int
             0-based index of recording
+            defaults to 0
         
         """
         
@@ -96,6 +99,8 @@ class Recording(ABC):
         self._continuous = None
         self._events = None
         self._spikes = None
+        
+        self.sync_lines = []
         
     @abstractmethod
     def load_spikes(self):
@@ -124,6 +129,120 @@ class Recording(ABC):
         """Returns a string with information about the Recording"""
         pass
     
+    def add_sync_channel(self, channel, nodeId, subprocessor=0, main=False):
+        """Specifies an event channel to use for timestamp synchronization. Each 
+        sync channel in a recording should receive its input from the same 
+        physical digital input line.
+        
+        For synchronization to work, there must be one (and only one) 'main' 
+        sync channel, to which all timestamps will be aligned.
+        
+        Parameters
+        ----------
+        channel : int
+            event channel number
+        nodeId : int
+            ID for the processor receiving sync events
+        subprocessor : int
+            index of the subprocessor receiving sync events
+            default = 0
+        main : bool
+            if True, this processor's timestamps will be treated as the 
+            main clock
+        
+        """
+        
+        if main:
+            existing_main = [sync for sync in self.sync_lines 
+                             if sync['main']]
+            
+            if len(existing_main) > 0:
+                raise Exception('Another main sync line already exists. ' + 
+                                'To override, add it again with main=False.')
+                
+        matching_node = [sync for sync in self.sync_lines 
+                         if sync['nodeId'] == nodeId and
+                            sync['subprocessor'] == subprocessor]
+        
+        if len(matching_node) == 1:
+            self.sync_lines.remove(matching_node[0])
+            warnings.warn('Another sync line exists for this node, overwriting.')
+        
+        self.sync_lines.append({'channel' : channel,
+                                'nodeId' : nodeId,
+                                'subprocessor' : subprocessor,
+                                'main' : main})
+        
+    def compute_global_timestamps(self):
+        """After sync channels have been added, this function computes the
+        global timestamps for all processors with a shared sync line.
+        
+        """
+        
+        if len(self.sync_lines) == 0:
+            raise Exception('At least two sync channels must be specified ' + 
+                            'using `add_sync_channel` before global timestamps ' + 
+                            'can be computed.')
+
+        main = [sync for sync in self.sync_lines 
+                             if sync['main']]
+        
+        aux_channels = [sync for sync in self.sync_lines 
+                             if not sync['main']]
+            
+        if len(main) == 0 or len(aux_channels) == 0:
+            raise Exception('Computing global timestamps requires one ' + 
+                            'main sync channel and at least one auxiliary ' +
+                            'sync channel.')
+            
+        main = main[0]
+            
+        main_events = self.events[(self.events.channel == main['channel']) & 
+                   (self.events.nodeId == main['nodeId']) & 
+                   (self.events.subprocessorId == main['subprocessor']) &
+                   (self.events.state == 1)]
+        
+        main_start_sample = main_events.iloc[0].timestamp
+        main_total_samples = main_events.iloc[-1].timestamp - main_start_sample
+        main['start'] = main_start_sample
+        main['scaling'] = 1
+        main['offset'] = main_start_sample
+        
+        for continuous in self.continuous:
+
+            if (continuous.metadata['processor_id'] == main['nodeId']) and \
+               (continuous.metadata['subprocessor_id'] == main['subprocessor']):
+               main['sample_rate'] = continuous.metadata['sample_rate']
+        
+        for aux in aux_channels:
+            
+            aux_events = self.events[(self.events.channel == aux['channel']) & 
+                   (self.events.nodeId == aux['nodeId']) & 
+                   (self.events.subprocessorId == aux['subprocessor']) &
+                   (self.events.state == 1)]
+            
+            aux_start_sample = aux_events.iloc[0].timestamp
+            aux_total_samples = aux_events.iloc[-1].timestamp - aux_start_sample
+            
+            aux['start'] = aux_start_sample
+            aux['scaling'] = main_total_samples / aux_total_samples
+            aux['offset'] = main_start_sample
+            aux['sample_rate'] = main['sample_rate']
+
+        for sync in self.sync_lines:
+            
+            for continuous in self.continuous:
+
+                if (continuous.metadata['processor_id'] == sync['nodeId']) and \
+                   (continuous.metadata['subprocessor_id'] == sync['subprocessor']):
+                       
+                    continuous.global_timestamps = \
+                        ((continuous.timestamps - sync['start']) * sync['scaling'] \
+                            + sync['offset']) / sync['sample_rate']
+                            
+                                              
+        
+        
     
         
     

--- a/open_ephys/streaming/event_listener.py
+++ b/open_ephys/streaming/event_listener.py
@@ -65,14 +65,21 @@ def run(hostname='localhost', port=5557):
         with ctx.socket(zmq.SUB) as sock:
             sock.connect('tcp://%s:%d' % (hostname, port))
 
-            for etype in (TTL, SPIKE, MESSAGE):
-                sock.setsockopt(zmq.SUBSCRIBE, chr(etype).encode('utf-8'))
+            for eventType in (b'ttl', b'spike'):
+                sock.setsockopt(zmq.SUBSCRIBE, eventType)
 
             while True:
                 try:
                     parts = sock.recv_multipart()
-                    assert len(parts) == 3
+                    #assert len(parts) == 3
 
+                    for part in parts:
+                        print(part)
+                except KeyboardInterrupt:
+                    print()  # Add final newline
+                    break
+
+"""
                     etype = ord(parts[0])
                     timestamp_seconds = struct.unpack('d', parts[1])[0]
                     body = parts[2]
@@ -103,6 +110,7 @@ def run(hostname='localhost', port=5557):
                 except KeyboardInterrupt:
                     print()  # Add final newline
                     break
+                    """
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Add basic synchronization capabilities, e.g.:

```
recording.add_sync_channel(8, 102, subprocessor=0, main=True)
recording.add_sync_channel(1, 100, subprocessor=0, main=False)
recording.compute_global_timestamps()
```
This will create a `global_timestamps` field for all `Continuous` objects and `Event` objects from processors that share a physical synchronization line.