### PR TITLE
sort sessions, experiments, and recordings naturally

### DIFF
--- a/src/open_ephys/analysis/formats/BinaryRecording.py
+++ b/src/open_ephys/analysis/formats/BinaryRecording.py
@@ -29,6 +29,7 @@ import pandas as pd
 import json
 
 from open_ephys.analysis.recording import Recording
+from open_ephys.analysis.utils import alphanum_key
 
 class BinaryRecording(Recording):
     
@@ -306,12 +307,12 @@ class BinaryRecording(Recording):
         recordings = []
         
         experiment_directories = glob.glob(os.path.join(directory, 'experiment*'))
-        experiment_directories.sort()
+        experiment_directories.sort(key=alphanum_key)
 
         for experiment_index, experiment_directory in enumerate(experiment_directories):
              
             recording_directories = glob.glob(os.path.join(experiment_directory, 'recording*'))
-            recording_directories.sort()
+            recording_directories.sort(key=alphanum_key)
             
             for recording_index, recording_directory in enumerate(recording_directories):
             

--- a/src/open_ephys/analysis/session.py
+++ b/src/open_ephys/analysis/session.py
@@ -28,6 +28,7 @@ import os
 import warnings
 
 from open_ephys.analysis.recordnode import RecordNode
+from open_ephys.analysis.utils import alphanum_key
 
 class Session:
     
@@ -71,7 +72,7 @@ class Session:
         
         recordnodepaths = glob.glob(os.path.join(self.directory, 
                                              'Record Node *'))
-        recordnodepaths.sort()
+        recordnodepaths.sort(key=alphanum_key)
         
         if len(recordnodepaths) == 0:
 

--- a/src/open_ephys/analysis/utils.py
+++ b/src/open_ephys/analysis/utils.py
@@ -1,0 +1,11 @@
+import re
+
+def alphanum_key(s):
+    """
+    Turn a string into a list of string and number chunks.
+
+    >>> alphanum_key("z23a")
+    ["z", 23, "a"]
+
+    """
+    return [int(c) if c.isdigit() else c for c in re.split('([0-9]+)', s) ]


### PR DESCRIPTION
This is a fix for #28 which also sorts the Recording Nodes naturally
I also encountered this issue when investigating #32 , I realized that when I was looking at `session.recordnodes[0].recordings[4]` and `session.recordnodes[0].recordings[5]`, those were not sequential recordings.