### PR TITLE
Allow `get_samples` to retrieve channels based on ID, not order in data array

### DIFF
--- a/src/open_ephys/analysis/README.md
+++ b/src/open_ephys/analysis/README.md
@@ -27,6 +27,8 @@ To access the data for the first Record Node, enter:
 recordnode = session.recordnodes[0]
 ```
 
+
+
 If data from multiple Record Nodes is stored in the same directory, you can use the `print` function to view information about the Record Nodes in the `Session` object, e.g.:
 
 ```
@@ -79,7 +81,14 @@ Because the memory-mapped samples are stored as 16-bit integers in arbitrary uni
 >> data = recording.continuous[0].get_samples(start_sample_index=0, end_sample_index=10000)
 ```
 
-This will return the first 10,000 continuous samples for all channels in units of microvolts. Note that your computer may run out of memory when requesting a large number of samples for many channels at once. It's also important to note that `start_sample_index` and `end_sample_index` represent relative indices in the `samples` array, rather than absolute sample numbers.
+This will return the first 10,000 continuous samples for all channels in units of microvolts. Note that your computer may run out of memory when requesting a large number of samples for many channels at once. It's also important to note that `start_sample_index` and `end_sample_index` represent relative indices in the `samples` array, rather than absolute sample numbers. The default behavior is to return all channels in the order in which they are stored, typically in increasing numerical order. However, if the `channel map` plugin is placed in the signal chain before a `record node`, the order of channels will follow the order of the specified channel mapping. 
+
+The `get_samples` method includes the arguments:
+
+- ``start_sample_index``
+- ``end_sample_index``
+- ``selected_channels`` is an optional argument allows channels to be selected via array index in the order stored in the sample array. 
+- ``channel_by_number`` is a keyword-only argument allows channels to be selected by ID to extract specific channels by channel ID number (integers following `CH` in the `oebin` file). If your board has additional ``ADCn`` channels, they are sequentially numbered after reaching the last ``CHnn`` labeled channel. 
 
 ### Using the Open Ephys data format
 

--- a/src/open_ephys/analysis/formats/BinaryRecording.py
+++ b/src/open_ephys/analysis/formats/BinaryRecording.py
@@ -122,7 +122,11 @@ class BinaryRecording(Recording):
                 Index of the first sample to return
             end_sample_index : int
                 Index of the last sample to return
-            selected_channels : numpy.ndarray
+            selected_channels : numpy.ndarray, optional
+                Array index of data to extract. The channel you will be returned is 
+                the argument+1 as arrays are zero-indexed. Internally, the channel returned 
+                will be looked up as described in ``channel_by_number``.
+            channel_by_number : numpy.ndarray, optional 
                 Channel number(s) that you request. The array index is looked-up from a 
                 dict that translates the channel ID (an interger of version of channel
                 name where ``'CH22' = 22``)  to the index of the storage array.
@@ -140,23 +144,27 @@ class BinaryRecording(Recording):
             if selected_channels and channel_by_number:
                 raise ValueError("Cannot use both ``selected_channels`` and ``channel_by_number`` channel selection methods") 
             elif selected_channels and not channel_by_number:
+                print("WARNING: You are selecting channels by array index, not channel ID!\n"
+                      "         Channel number will be the array index +1 by default\n"
+                      "         Use ``channel_by_number`` keyword to select channels by ID\n"
+                      "           This is important when channel ordering has changed due to\n"
+                      "           the use of the channel selector plugin.")
+
                 if type(selected_channels) is int:
-                    selected_channels = np.array([int],dtype=np.uint32)
-                    selected_channels -= 1 
-                elif isinstance(np.ndarray,selected_channels):
-                    selected_channels -= 1 
+                    selected_channels = np.array([selected_channels],dtype=np.uint32)
+                    selected_channels += 1 
+                elif isinstance(np.ndarray,type(selected_channels)):
+                    selected_channels += 1 
                 else:
                     selected_channels = np.array(selected_channels,dtype=np.uint32)
-                    selected_channels -= 1 
+                    selected_channels += 1 
             elif not selected_channels and channel_by_number:
                 if type(channel_by_number) is int:
-                    selected_channels = np.array([int],dtype=np.uint32)
-                    selected_channels -= 1 
-                elif isinstance(np.ndarray,channel_by_number):
-                    selected_channels -= 1 
+                    selected_channels = np.array([channel_by_number],dtype=np.uint32)
+                elif isinstance(np.ndarray,type(channel_by_number)):
+                    pass
                 else:
                     selected_channels = np.array(channel_by_number,dtype=np.uint32)
-                    selected_channels -= 1 
             else:
                 selected_channels = np.arange(self.metadata['num_channels'],dtype=np.uint32)
                 selected_channels += 1 #change index to match channel ID, not array index

--- a/src/open_ephys/analysis/formats/NwbRecording.py
+++ b/src/open_ephys/analysis/formats/NwbRecording.py
@@ -67,6 +67,7 @@ class NwbRecording(Recording):
 
             self.metadata['sample_rate'] = np.around(1 / nwb['acquisition'][dataset]['timestamps'].attrs['interval'], 1)
             self.metadata['num_channels'] = nwb['acquisition'][dataset]['data'].shape[1]
+            self.metadata['channel_map'] = self.create_channel_map(info)
             self.metadata['bit_volts'] = \
                     list(nwb['acquisition'][dataset]['channel_conversion'][()] * 1e6)
 

--- a/src/open_ephys/analysis/formats/OpenEphysRecording.py
+++ b/src/open_ephys/analysis/formats/OpenEphysRecording.py
@@ -80,6 +80,8 @@ class OpenEphysRecording(Recording):
             self.metadata['num_channels'] = len(files)
 
             self.metadata['channel_names'] = info['channel_names']
+            self.metadata['channel_map'] = self.create_channel_map(info)
+
             self.metadata['bit_volts'] = info['bit_volts']
 
             self._load_timestamps()
@@ -118,12 +120,14 @@ class OpenEphysRecording(Recording):
             """
 
             if selected_channels is None:
-                selected_channels = np.arange(self.selected_channels.size)
+                selected_channels = np.arange(self.selected_channels.size,dtype=np.uint32)
 
-            samples = self.samples[start_sample_index:end_sample_index, selected_channels].astype('float64')
+            selected_ch = np.array([ self.metadata['channel_map'][ch] for ch in selected_channels ],dtype=np.uint32)
 
-            for idx, channel in enumerate(selected_channels):
-                samples[:,idx] = samples[:,idx] * self.metadata['bit_volts'][self.selected_channels[channel]]
+            samples = self.samples[start_sample_index:end_sample_index, selected_ch].astype('float64')
+
+            for idx, ch in enumerate(selected_ch):
+                samples[:,idx] = samples[:,idx] * self.metadata['bit_volts'][ch]
 
             return samples
 

--- a/src/open_ephys/analysis/formats/OpenEphysRecording.py
+++ b/src/open_ephys/analysis/formats/OpenEphysRecording.py
@@ -78,6 +78,8 @@ class OpenEphysRecording(Recording):
 
             self.metadata['sample_rate'] = info['sample_rate']
             self.metadata['num_channels'] = len(files)
+            if selected_channels is None:
+                selected_channels = np.arange(self.selected_channels.size,dtype=np.uint32)
 
             self.metadata['channel_names'] = info['channel_names']
             self.metadata['channel_map'] = Recording.create_channel_map(info)
@@ -95,7 +97,7 @@ class OpenEphysRecording(Recording):
                 self.reload_required = False
             return self._samples
 
-        def get_samples(self, start_sample_index, end_sample_index, selected_channels=None):
+        def get_samples(self, start_sample_index, end_sample_index, selected_channels=None, *, channel_by_number = None):
             """
             Returns samples scaled to microvolts. Converts sample values
             from 16-bit integers to 64-bit floats.
@@ -109,9 +111,18 @@ class OpenEphysRecording(Recording):
                 Index of the first sample to return
             end_sample_index : int
                 Index of the last sample to return
-            selected_channels : numpy.ndarray
-                Indices of the channels to return
-                By default, all channels are returned
+            selected_channels : numpy.ndarray, optional
+                Array index of data to extract. The channel you will be returned is 
+                the argument+1 as arrays are zero-indexed. Internally, the channel returned 
+                will be looked up as described in ``channel_by_number``.
+            channel_by_number : numpy.ndarray, optional
+                Channel number(s) that you request. The array index is looked-up from a 
+                dict that translates the channel ID (an interger of version of channel
+                name where ``'CH22' = 22``)  to the index of the storage array.
+                Order is kept consisitent with the **Channel Map** plugin as recorded in the 
+`               ``oebin`` file. By default, all channels are returned. If you board has 
+                additional ``ADCn`` channels, they are sequentially numbered after reaching
+                the last ``CHnn`` labeled channel. 
 
             Returns
             -------
@@ -119,8 +130,33 @@ class OpenEphysRecording(Recording):
 
             """
 
-            if selected_channels is None:
-                selected_channels = np.arange(self.selected_channels.size,dtype=np.uint32)
+            if selected_channels and channel_by_number:
+                raise ValueError("Cannot use both ``selected_channels`` and ``channel_by_number`` channel selection methods") 
+            elif selected_channels and not channel_by_number:
+                print("WARNING: You are selecting channels by array index, not channel ID!\n"
+                      "         Channel number will be the array index +1 by default\n"
+                      "         Use ``channel_by_number`` keyword to select channels by ID\n"
+                      "           This is important when channel ordering has changed due to\n"
+                      "           the use of the channel selector plugin.")
+
+                if type(selected_channels) is int:
+                    selected_channels = np.array([selected_channels],dtype=np.uint32)
+                    selected_channels += 1 
+                elif isinstance(np.ndarray,type(selected_channels)):
+                    selected_channels += 1 
+                else:
+                    selected_channels = np.array(selected_channels,dtype=np.uint32)
+                    selected_channels += 1 
+            elif not selected_channels and channel_by_number:
+                if type(channel_by_number) is int:
+                    selected_channels = np.array([channel_by_number],dtype=np.uint32)
+                elif isinstance(np.ndarray,type(channel_by_number)):
+                    pass
+                else:
+                    selected_channels = np.array(channel_by_number,dtype=np.uint32)
+            else:
+                selected_channels = np.arange(self.metadata['num_channels'],dtype=np.uint32)
+                selected_channels += 1 #change index to match channel ID, not array index
 
             selected_ch = np.array([ self.metadata['channel_map'][ch] for ch in selected_channels ],dtype=np.uint32)
 

--- a/src/open_ephys/analysis/formats/OpenEphysRecording.py
+++ b/src/open_ephys/analysis/formats/OpenEphysRecording.py
@@ -80,7 +80,7 @@ class OpenEphysRecording(Recording):
             self.metadata['num_channels'] = len(files)
 
             self.metadata['channel_names'] = info['channel_names']
-            self.metadata['channel_map'] = self.create_channel_map(info)
+            self.metadata['channel_map'] = Recording.create_channel_map(info)
 
             self.metadata['bit_volts'] = info['bit_volts']
 

--- a/src/open_ephys/analysis/recording.py
+++ b/src/open_ephys/analysis/recording.py
@@ -225,9 +225,25 @@ class Recording(ABC):
 
     @staticmethod    
     def create_channel_map(info):
-        """ Create channel map to generate list of channel names that map to
-            indices. The `channels` key maps to an (ordered) 
-            list of channels with tags of the form CHn, or ADCn.
+        """ Create channel map to generate list of channel 
+        names that map to indices. The `channels` key maps 
+        to an (ordered) list of channels with tags of the 
+        form CHn, or ADCn. Notes regarding conversion of 
+        channel to array index map:
+        
+            The addition of +1 to channels that are not 
+            have repeat indices (with different 
+            leading charactars) is important as it 
+            keeps the channel numbering consistennt 
+            so that channels match their ID, not their 
+            array index!
+            
+            If channel #64 is the last CHn channel
+            followed by AC1, then the AC1 channel 
+            should be 65 to always allow an integer 
+            index to each channel and count on
+            the user having to use array index
+            for non CHn labeled channels.
 
         Parameters
         ----------
@@ -242,23 +258,6 @@ class Recording(ABC):
 
         channel_map = {}
         
-        print("Channel ID, index")
-        #
-        #  Notes channel to array index map:
-        #
-        # The addition of +1 to channels that are not 
-        # have repeat indices (with different 
-        # leading charactars) is important as it 
-        # keeps the channel numbering consistennt 
-        # so that channels match their ID, not their 
-        # array index!
-        #
-        # If channel #64 is the last CHn channel
-        #   followed by AC1, then the AC1 channel 
-        #   should be 65 to always allow an integer 
-        #   index to each channel and count on
-        #   the user having to use array index
-        #   for non CHn labeled channels.
         for i,c in enumerate(channel_names):
             if c.startswith('CH'):
                 ch_id = int(c.lstrip('CH'))

--- a/src/open_ephys/analysis/recording.py
+++ b/src/open_ephys/analysis/recording.py
@@ -223,7 +223,7 @@ class Recording(ABC):
                                 'main' : main,
                                 'ignore_intervals' : ignore_intervals})
 
-    @static_method    
+    @staticmethod    
     def create_channel_map(info):
         """ Create channel map to generate list of channel names that map to
             indices. The `channels` key maps to an (ordered) 
@@ -242,20 +242,31 @@ class Recording(ABC):
 
         channel_map = {}
         
+        print("Channel ID, index")
+        #
+        #  Notes channel to array index map:
+        #
+        # The addition of +1 to channels that are not 
+        # have repeat indices (with different 
+        # leading charactars) is important as it 
+        # keeps the channel numbering consistennt 
+        # so that channels match their ID, not their 
+        # array index!
+        #
+        # If channel #64 is the last CHn channel
+        #   followed by AC1, then the AC1 channel 
+        #   should be 65 to always allow an integer 
+        #   index to each channel and count on
+        #   the user having to use array index
+        #   for non CHn labeled channels.
         for i,c in enumerate(channel_names):
             if c.startswith('CH'):
                 ch_id = int(c.lstrip('CH'))
             elif c.startswith('ADC'):
-                ch_id = i
+                ch_id = i+1
             else:
-                ch_id = i
+                ch_id = i+1
             channel_map[ch_id] = i
-
-        print("check channel len: ", info['num_channels'], ' against ', len(self.metadata['channel_names'])))
-        print("channel names: ", self.metadata['channel_names'])
-        print('channel_map" : ')
-        for ch, idx in self.metadata['channel_map']:
-            print('\t',ch, idx)
 
         return channel_map
 

--- a/src/open_ephys/analysis/recording.py
+++ b/src/open_ephys/analysis/recording.py
@@ -222,7 +222,43 @@ class Recording(ABC):
                                 'stream_name' : stream_name,
                                 'main' : main,
                                 'ignore_intervals' : ignore_intervals})
+
+    @static_method    
+    def create_channel_map(info):
+        """ Create channel map to generate list of channel names that map to
+            indices. The `channels` key maps to an (ordered) 
+            list of channels with tags of the form CHn, or ADCn.
+
+        Parameters
+        ----------
+        info : dict
+
+        Returns
+        -------
+        channel_map: dict
+
+        """
+        channel_names = [ch['channel_name'] for ch in info['channels']]
+
+        channel_map = {}
         
+        for i,c in enumerate(channel_names):
+            if c.startswith('CH'):
+                ch_id = int(c.lstrip('CH'))
+            elif c.startswith('ADC'):
+                ch_id = i
+            else:
+                ch_id = i
+            channel_map[ch_id] = i
+
+        print("check channel len: ", info['num_channels'], ' against ', len(self.metadata['channel_names'])))
+        print("channel names: ", self.metadata['channel_names'])
+        print('channel_map" : ')
+        for ch, idx in self.metadata['channel_map']:
+            print('\t',ch, idx)
+
+        return channel_map
+
     def compute_global_timestamps(self, overwrite=False):
         """After sync channels have been added, this function computes the
         global timestamps for all processors with a shared sync line.


### PR DESCRIPTION
# Problem

The default behavior for `get_samples` is to return all channels in the order in which they are stored, typically in increasing numerical order. However, if the `channel map` plugin is placed in the signal chain before a `record node`, the order of channels will follow the order of the specified channel mapping, but no indication is given to the user that the channel ordering is not 1--n as without the `channel map` plugin.

# Solution

The array index is looked-up from a  dictionary that translates the channel ID (an integer of version of channel name, where ``'CH22' = 22``)  to the index of the storage array.
Order is kept consistent with the ``channel map`` plugin as recorded in the 
``oebin`` file. By default, all channels are returned. If you board has 
additional ``ADCn`` channels, they are sequentially numbered after reaching
the last ``CHnn`` labeled channel. 

This PR allows for the user to specify channel by it's ID, not it's index. This will allow for a direct selection of channels via the `channel_by_number` argument, where index 1 == 'CH1' .

# Changes

The `get_samples` method now includes the arguments:

- ``selected_channels`` is a positional or keyword argument that allows channels to be selected via array index in the order stored in the sample array.
   Superficially similar to the existing approach, the selected channels area always selected using the channel map dictionary, such that the user gets the channel they intend, but indices are consistent with python 0-based arrays. 

- ``channel_by_number``  is a keyword-only argument allows channels to be selected by ID to extract specific channels by channel ID number (integers following `CH` in the `oebin` file). If your board has additional ``ADCn`` channels, they are sequentially numbered after reaching the last ``CHnn`` labeled channel.

The changes *only* apply to binary and oebin formats. I am not familiar with NWB format and I do not know if it needs such a change. 